### PR TITLE
Fix Express deployment routing on Vercel

### DIFF
--- a/back/app.js
+++ b/back/app.js
@@ -7,7 +7,30 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
+app.get('/', (req, res) => {
+  res.status(200).json({
+    message: 'ArtistBook API is running',
+    status: 'ok',
+  });
 });
+
+app.get('/api/health', (req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+app.use((req, res) => {
+  res.status(404).json({
+    error: 'Route not found',
+    path: req.originalUrl,
+  });
+});
+
+const PORT = process.env.PORT || 5000;
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/back/vercel.json
+++ b/back/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "app.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "app.js"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "installCommand": "cd back && yarn install --frozen-lockfile",
+  "builds": [
+    {
+      "src": "back/app.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "back/app.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- The deployed app returned Vercel's `404: NOT_FOUND` because there was no `GET /` handler and the Express app wasn't exported for serverless invocation. 
- The repository needs to support both root-level and `back`-directory deployments on Vercel, so explicit routing configuration is required. 
- A clearer JSON 404 response is desirable to diagnose missing routes instead of Vercel's generic error page.

### Description
- Added a root route `GET /` that returns a simple JSON status and a `GET /api/health` endpoint for quick checks in `back/app.js`.
- Added a JSON 404 handler that returns `{ error: 'Route not found', path }` for missing routes.
- Made the server only `listen` when run directly using `if (require.main === module)` and exported the Express app with `module.exports = app` to make it importable by Vercel's serverless builder.
- Added `vercel.json` at the repo root and `back/vercel.json` to map all routes to the Express entry (`back/app.js` or `app.js`) so both deployment layouts are supported.

### Testing
- Verified the app is exportable with `node -e "const app = require('./back/app'); console.log(typeof app)"` and it returned `function` (success).
- Ran `node back/app.js` and used `curl` to request `/` and `/api/health`, both returned `200` with the expected JSON (success).
- Requested a missing path with `curl /missing` and received the custom `404` JSON response (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023995c3dc8332839c234276fa8bde)