### PR TITLE
Add Vercel deployment guide and configuration for monorepo frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ artistBook/
 └── 📄 README.md               # This file
 ```
 
+## 🚢 Deployment note
+
+If Vercel reports `Root Directory "front" does not exist`, check the dedicated [Vercel deployment guide](docs/vercel-deployment.md). That error happens before the frontend build starts and usually means the Vercel project Root Directory setting does not match the selected Git commit.
+
 ## 🚀 Quick Start
 
 ### **Prerequisites**

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -1,0 +1,50 @@
+# Vercel deployment guide
+
+This project is a monorepo with two main folders:
+
+- `front/`: React + Vite frontend.
+- `back/`: Express + Prisma backend.
+
+## Why Vercel can show `Root Directory "front" does not exist`
+
+That message happens before the build command runs. It means Vercel cloned a Git commit and then tried to enter the Root Directory configured in the Vercel dashboard, but that folder was not present in that specific commit.
+
+In other words, this is not a React Router error and it is not caused by the SPA rewrite. It is a project configuration / Git commit visibility problem.
+
+## Recommended frontend deployment from the repository root
+
+Use this option when the Vercel project is connected to the root of this repository.
+
+1. In Vercel, open the project settings.
+2. Go to **Settings → General → Root Directory**.
+3. Leave **Root Directory** empty, or set it to the repository root.
+4. Let Vercel use the root `vercel.json` file.
+
+The root `vercel.json` installs dependencies inside `front/`, builds the Vite app, publishes `front/dist`, and rewrites all frontend routes to `index.html` so React Router can handle them in the browser.
+
+## Alternative frontend deployment from `front/`
+
+Use this option only if the selected Git commit definitely contains the `front/` folder.
+
+1. In Vercel, open the project settings.
+2. Go to **Settings → General → Root Directory**.
+3. Set **Root Directory** to `front`.
+4. Redeploy from a branch/commit where `front/package.json` exists.
+
+With this option, Vercel reads `front/vercel.json`, runs `npm run build`, publishes `dist`, and uses the same SPA rewrite.
+
+## Quick debugging checklist
+
+If Vercel says `Root Directory "front" does not exist`, check these items in order:
+
+1. Confirm the deployment branch is the branch you expect.
+2. Confirm the commit shown in the Vercel logs contains the `front/` directory.
+3. In GitHub, open that exact commit and verify `front/package.json` is visible.
+4. If `front/` is not visible in that commit, push the latest branch or deploy from the repository root instead.
+5. If `front/` is visible but Vercel still fails, disconnect/reconnect the Git project or clear the Root Directory setting and redeploy.
+
+## How to think about the original 404
+
+A Vite app produces static files in `dist/`. The server knows about files like `index.html`, but it does not know about client-side routes like `/dashboard`, `/entries/123`, or `/login`.
+
+React Router resolves those routes after `index.html` loads in the browser. For that reason, Vercel needs a rewrite from every frontend path to `/index.html`.

--- a/front/vercel.json
+++ b/front/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "cd front && npm install",
+  "buildCommand": "cd front && npm run build",
+  "outputDirectory": "front/dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Clarify and resolve the common Vercel error `Root Directory "front" does not exist` for this monorepo by explaining its root-cause and recommended workflows.
- Provide deployment configuration so Vercel can build and publish the Vite React frontend from either the repository root or the `front/` folder.
- Reduce friction for future deploys by documenting debugging steps and explicit config files for both root and frontend-level deployment modes.

### Description
- Added a detailed guide at `docs/vercel-deployment.md` that explains why the `Root Directory "front" does not exist` message occurs and provides recommended settings and a debugging checklist. 
- Added a root `vercel.json` that installs and builds the frontend from the repository root using `cd front && npm install` and `cd front && npm run build`, sets `front/dist` as the `outputDirectory`, and rewrites SPA routes to `index.html`.
- Added `front/vercel.json` for deployments that target the `front/` folder directly, with `buildCommand`, `outputDirectory`, and SPA rewrite rules.
- Updated `README.md` to include a `Deployment note` pointing to the new Vercel deployment guide and explaining the common Root Directory error.

### Testing
- No automated tests were run for these documentation and configuration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023b7d0d0083329aa88b641c785aec)