### PR TITLE
Make dashboard resilient to profile sync failures

### DIFF
--- a/front/src/contexts/AuthContext.jsx
+++ b/front/src/contexts/AuthContext.jsx
@@ -4,17 +4,28 @@ import { onAuthStateChanged, signOut } from 'firebase/auth';
 import api, { getUserProfile } from '../utils/api';
 
 const AuthContext = createContext();
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => useContext(AuthContext);
+
+const buildFallbackUserData = (user) => ({
+  id: user.uid,
+  email: user.email,
+  name: user.displayName || user.email?.split('@')[0] || 'Artist',
+  role: 'USER',
+  isFallback: true
+});
 
 export const AuthProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
-  const [userData, setUserData] = useState(null); 
+  const [userData, setUserData] = useState(null);
+  const [profileError, setProfileError] = useState(null);
   const [loading, setLoading] = useState(true);
 
   const logout = async () => {
     try {
       await signOut(auth);
       setUserData(null);
+      setProfileError(null);
       localStorage.removeItem('authToken');
       delete api.defaults.headers.common['Authorization'];
     } catch (error) {
@@ -25,29 +36,30 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setCurrentUser(user);
+      setProfileError(null);
 
       if (user) {
         try {
           const token = await user.getIdToken();
           localStorage.setItem('authToken', token);
           api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-          
-          // Fetch user profile from backend
+
           try {
             const res = await getUserProfile();
-            const userData = res.data.data;
-            setUserData(userData);
-            
-            // Guardar el ID del usuario para referencia
-            localStorage.setItem('userId', userData.id);
-            
+            const backendUserData = res.data.data;
+            setUserData(backendUserData);
+            localStorage.setItem('userId', backendUserData.id);
           } catch (profileError) {
             console.error('Error fetching profile:', profileError);
-            setUserData(null);
+            setUserData(buildFallbackUserData(user));
+            setProfileError(profileError);
+            localStorage.removeItem('userId');
           }
         } catch (err) {
           console.error('Error in auth state change:', err);
-          setUserData(null);
+          setUserData(buildFallbackUserData(user));
+          setProfileError(err);
+          localStorage.removeItem('userId');
         }
       } else {
         // User signed out
@@ -55,6 +67,7 @@ export const AuthProvider = ({ children }) => {
         localStorage.removeItem('userId');
         delete api.defaults.headers.common['Authorization'];
         setUserData(null);
+        setProfileError(null);
       }
 
       setLoading(false);
@@ -66,7 +79,8 @@ export const AuthProvider = ({ children }) => {
   const value = {
     currentUser,
     userData,
-    isAdmin: userData?.role === 'ADMIN',
+    profileError,
+    isAdmin: userData?.role === 'ADMIN' && !userData?.isFallback,
     loading,
     logout
   };

--- a/front/src/pages/AdminPanel.jsx
+++ b/front/src/pages/AdminPanel.jsx
@@ -43,7 +43,7 @@ export default function AdminPanel() {
       );
       
       if (confirmed) {
-        const response = await api.put(`/users/${user.id}`, {
+        await api.put(`/users/${user.id}`, {
           role: newRole
         });
         

--- a/front/src/pages/Dashboard.jsx
+++ b/front/src/pages/Dashboard.jsx
@@ -1,100 +1,30 @@
-import React, { useState, useEffect } from 'react';
-import { useAuth } from '../contexts/AuthContext';
 import Entries from './Entries';
-import api from '../utils/api';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function Dashboard() {
-  const { currentUser } = useAuth();
-  const [profile, setProfile] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-
-  useEffect(() => {
-    const fetchProfile = async () => {
-      try {
-        console.log('Fetching profile...'); // DEBUG
-        
-        // ✅ RUTA CORRECTA: /api/users/profile
-        const response = await api.get('/users/profile');
-        
-        console.log('Profile response:', response.data); // DEBUG
-        setProfile(response.data.data);
-      } catch (err) {
-        console.error('Error fetching profile:', err.response || err);
-        setError('Failed to load your profile');
-      } finally {
-        setLoading(false);
-      }
-    };
-    
-    fetchProfile();
-  }, []);
-
-  // Loading state
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center px-4">
-        <section className="text-center" role="status" aria-live="polite">
-          <svg 
-            className="animate-spin -ml-1 mr-3 h-8 w-8 text-indigo-600 mx-auto mb-4" 
-            xmlns="http://www.w3.org/2000/svg" 
-            fill="none" 
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-          <p className="text-base sm:text-lg text-gray-600">Loading dashboard...</p>
-        </section>
-      </div>
-    );
-  }
-
-  // Error state
-  if (error) {
-    return (
-      <div className="min-h-screen flex items-center justify-center px-4">
-        <section className="text-center max-w-sm sm:max-w-md mx-auto p-6 sm:p-8">
-          <svg 
-            className="mx-auto h-10 w-10 sm:h-12 sm:w-12 text-red-500 mb-4" 
-            xmlns="http://www.w3.org/2000/svg" 
-            fill="none" 
-            viewBox="0 0 24 24" 
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
-          </svg>
-          <h1 className="text-lg sm:text-xl font-semibold text-gray-900 mb-2">Dashboard Error</h1>
-          <p role="alert" className="text-sm sm:text-base text-red-600 mb-4">{error}</p>
-          <button 
-            onClick={() => window.location.reload()}
-            className="w-full sm:w-auto bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-          >
-            Try Again
-          </button>
-        </section>
-      </div>
-    );
-  }
+  const { currentUser, userData, profileError } = useAuth();
+  const displayName = userData?.name || currentUser?.displayName || currentUser?.email || 'Artist';
+  const profileStatus = profileError?.response?.status;
 
   return (
     <div className="max-w-7xl mx-auto py-6 sm:py-8 lg:py-10 px-4 sm:px-6 lg:px-8">
-      
-      {/* Welcome header - Mobile optimized */}
       <header className="mb-6 sm:mb-8">
         <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-900 mb-2">
-          Welcome, {profile?.name || currentUser.email}
+          Welcome, {displayName}
         </h1>
-        {profile?.role && (
+        {userData?.role && !userData?.isFallback && (
           <p className="text-base sm:text-lg text-gray-600">
-            Role: <span className="font-medium text-indigo-600">{profile.role}</span>
+            Role: <span className="font-medium text-indigo-600">{userData.role}</span>
+          </p>
+        )}
+        {profileError && (
+          <p role="status" className="mt-3 rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            We could not sync your backend profile{profileStatus ? ` (status ${profileStatus})` : ''},
+            but you are signed in with Firebase. Some account-specific data may be limited until the API profile route responds.
           </p>
         )}
       </header>
 
-      {/* Entries section */}
       <section aria-labelledby="entries-section">
         <h2 id="entries-section" className="sr-only">Your Entries</h2>
         <Entries />

--- a/front/src/pages/Entries.jsx
+++ b/front/src/pages/Entries.jsx
@@ -92,6 +92,11 @@ export default function Entries() {
         </header>
         
         {/* Entries content */}
+        {error && (
+          <p role="alert" className="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </p>
+        )}
         <section className="bg-white rounded-lg shadow-sm">
           {entries.length === 0 ? (
             <div className="text-center py-12 px-4 sm:px-6">

--- a/front/src/utils/firebase.js
+++ b/front/src/utils/firebase.js
@@ -1,6 +1,4 @@
-
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
 
@@ -17,7 +15,6 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
 export const auth = getAuth(app);
 export const storage = getStorage(app);
 


### PR DESCRIPTION
### Motivation

- The dashboard assumed the backend `/api/users/profile` would always respond, causing a full error state when the profile request failed while Firebase authentication was still valid.
- We want the app to remain usable when the backend profile route is temporarily unavailable and to show a non-blocking warning instead of breaking the UI.

### Description

- Centralized profile loading in `AuthContext` and added a Firebase-based fallback user created by `buildFallbackUserData(user)` when the backend profile request fails, and persisted a `profileError` for UI feedback (`front/src/contexts/AuthContext.jsx`).
- Updated `Dashboard` to consume `currentUser`, `userData` and `profileError` from the auth context, render a safe `displayName` and show a non-blocking warning when backend profile sync fails instead of blocking the dashboard (`front/src/pages/Dashboard.jsx`).
- Surface entries load errors directly in the Entries UI and fixed minor lint issues (unused `response`) in admin role update flow (`front/src/pages/Entries.jsx`, `front/src/pages/AdminPanel.jsx`).
- Removed unused Firebase Analytics initialization to silence related console/cookie warnings and avoid unused-variable lint errors (`front/src/utils/firebase.js`).

### Testing

- Ran `npm run lint` in the frontend; lint now passes with only one non-blocking warning related to fast-refresh export style (no errors).
- Built the frontend with `npm run build` (Vite); build succeeded with the normal chunk-size warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03420f26848332aab717e013ffe511)